### PR TITLE
Update .gitignore to match default Godot gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+
+# Godot-specific ignores
+game/.import/
+game/export.cfg
+game/export_presets.cfg
+
+# Because peter uses a mac
 .DS_store
-*.import


### PR DESCRIPTION
https://github.com/rockandpunkgames/violaceous/issues/14

Github has a default .gitignore for Godot, and it appears to be updated for 3.0. I say we trust it.